### PR TITLE
Change toString() into toString(16) for hex strings in node scripts

### DIFF
--- a/src/micro/analytic/ethereum/bench_q1.js
+++ b/src/micro/analytic/ethereum/bench_q1.js
@@ -21,7 +21,7 @@ function get_total(block_num) {
     "jsonrpc": "2.0",
       "method": "eth_getBlockByNumber",
       "params": 
-    ["0x"+block_num.toString(), true],
+    ["0x"+block_num.toString(16), true],
       "id": 3
   });
 

--- a/src/micro/analytic/ethereum/bench_q2.js
+++ b/src/micro/analytic/ethereum/bench_q2.js
@@ -22,7 +22,7 @@ function get_max(block_num) {
     "jsonrpc": "2.0",
       "method": "eth_getBlockByNumber",
       "params": 
-    ["0x"+block_num.toString(), true],
+    ["0x"+block_num.toString(16), true],
       "id": 3
   });
 

--- a/src/micro/analytic/ethereum/bench_q3.js
+++ b/src/micro/analytic/ethereum/bench_q3.js
@@ -22,7 +22,7 @@ function get_max(block_num) {
     "jsonrpc": "2.0",
       "method": "eth_getBalance",
       "params": 
-    [acc, "0x" + block_num.toString()],
+    [acc, "0x" + block_num.toString(16)],
       "id": 3
   });
 

--- a/src/micro/analytic/hyperledger/bench_q2.js
+++ b/src/micro/analytic/hyperledger/bench_q2.js
@@ -7,7 +7,7 @@ if (process.argv.length >= 6) {
 
 function gen_acc(n) {
   var zeros = "00000000000000000000"
-  var str = n.toString();
+  var str = n.toString(16);
   return "0x"+zeros.slice(str.length)+str;
 }
 

--- a/src/micro/analytic/hyperledger/populate.js
+++ b/src/micro/analytic/hyperledger/populate.js
@@ -9,7 +9,7 @@ if (process.argv.length >= 4) {
 var zipfGenerator = require('zipfian').getGenerator(99999);
 function gen_acc(n) {
   var zeros = "00000000000000000000"
-  var str = n.toString();
+  var str = n.toString(16);
   return "0x"+zeros.slice(str.length)+str;
 }
 

--- a/src/micro/ethereum_script/start_ethereum.sh
+++ b/src/micro/ethereum_script/start_ethereum.sh
@@ -10,6 +10,16 @@ rm -rf $ETH_DATA/{geth,keystore}
 mkdir -p $ETH_DATA/keystore
 cp ./key/* $ETH_DATA/keystore
 
+# miner threads
+NM=1
+if [ $# -gt 0 ]; then
+	NM=$1
+fi
+echo "Starting geth with $NM miner threads"
+
 # ------------private chain(10 accounts)------------
+# geth 1.4.18 uses --minerthreads
+# geth 1.8.15 uses --miner.threads
+
 $GETH --datadir=$ETH_DATA init genesis.json
-$GETH --datadir=$ETH_DATA --nodiscover --rpcapi="db,eth,net,web3,personal,web3" --rpc --rpcaddr "localhost" --rpcport "8545" --rpccorsdomain "*" --gasprice 0 --maxpeers 32 --networkid 9119 --unlock "0x12f029d57082315085bfb4d4d8345c92c5cdd881" --password <(echo -n "") --mine --minerthreads 4
+$GETH --datadir=$ETH_DATA --nodiscover --rpcapi="db,eth,net,web3,personal,web3" --rpc --rpcaddr "localhost" --rpcport "8545" --rpccorsdomain "*" --gasprice 0 --maxpeers 32 --networkid 9119 --unlock "0x12f029d57082315085bfb4d4d8345c92c5cdd881" --password <(echo -n "") --mine --minerthreads $NM > /dev/null 2>&1 &


### PR DESCRIPTION
Since hex numbers are used in the request, toString(16) should be used. Otherwise, users will get errors such as:
"Running analytics Q1 from block 1 to 10000
checking: 10000
Err: There is not so many block minted!" 