### PR TITLE
Fixed incorrect header import and improved instructions in README

### DIFF
--- a/benchmark/fabric-v2.2/README.md
+++ b/benchmark/fabric-v2.2/README.md
@@ -45,7 +45,7 @@ node block-server.js ${CHANNEL_NAME} 8800 > block-server.log 2>&1 &
 ```
 
 Launch two transaction services on port 8801 and 8802 respectively in the background, each listening for json requests and routes them to Fabric network. 
-`$MODE` is determined by individual benchmarks. In most cases, macro benchmarks opt for `$MODE=open_loop` and micro benchmarks opt for `$MODE=closed_loop`. 
+`$MODE` is determined by individual benchmarks. In most cases, macro benchmarks opt for `MODE=open_loop` and micro benchmarks opt for `MODE=closed_loop`. 
 ```
 # Still in services/
 node txn-server.js ${CHANNEL_NAME} ${CC_NAME} ${MODE} 8801 > txn-server-8801.log 2>&1 &

--- a/src/macro/kvstore/core/fabricv2_util.cc
+++ b/src/macro/kvstore/core/fabricv2_util.cc
@@ -1,4 +1,4 @@
-#include "hyperledger_utils.h"
+#include "fabricv2_utils.h"
 
 namespace BBUtils {
 namespace FABV2Utils {


### PR DESCRIPTION
I found that fabricv2 does not import the correct header file, so I fixed that.

I also removed the $ from README to make it easier to copy and paste the commands.